### PR TITLE
Fixed GitHub actions badge image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build with Zig 0.11.0](https://github.com/marnix/zig-ray-tracer-challenge-marnix/workflows/Build%20with%20zig%200.11.x/badge.svg?branch=main)](https://github.com/marnix/zig-ray-tracer-challenge-marnix/actions?query=branch%3Amain)
+[![Build with Zig 0.11.0](https://github.com/marnix/zig-ray-tracer-challenge-marnix/actions/workflows/ci-workflow.yaml/badge.svg?branch=main)](https://github.com/marnix/zig-ray-tracer-challenge-marnix/actions?query=branch%3Amain)
 
 Today, November 8, 2023, "The Ray Tracer Challenge --
 A Test-Driven Guide to Your First 3D Renderer"


### PR DESCRIPTION
Before this change, always 'no status' was shown.
This change was inspired by https://stackoverflow.com/a/72774291/223837.