### PR TITLE
Update to Zig 0.13.0

### DIFF
--- a/.github/workflows/ci-workflow.yaml
+++ b/.github/workflows/ci-workflow.yaml
@@ -1,4 +1,4 @@
-name: Build with zig 0.12.x
+name: Build with zig 0.13.x
 
 on:
   push:
@@ -15,6 +15,6 @@ jobs:
           submodules: recursive
       - uses: goto-bus-stop/setup-zig@v2
         with:
-          version: 0.12.0
+          version: 0.13.0
       - run: zig build test --verbose
       - run: zig fmt --check .

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@
 # [core]
 #     excludesfile = ~/.gitignore
 
+.zig-cache/
+# the following was used before Zig 0.13.0
 zig-cache/
 zig-out/
 /release/

--- a/build.zig
+++ b/build.zig
@@ -6,7 +6,7 @@ pub fn build(b: *std.Build) void {
 
     {
         const unit_tests = b.addTest(.{
-            .root_source_file = .{ .path = "src/alltests.zig" },
+            .root_source_file = b.path("src/alltests.zig"),
             .target = target,
             .optimize = optimize,
         });
@@ -19,7 +19,7 @@ pub fn build(b: *std.Build) void {
     {
         const exe = b.addExecutable(.{
             .name = "chapter-01-cannon",
-            .root_source_file = .{ .path = "src/chapter-01-cannon.zig" },
+            .root_source_file = b.path("src/chapter-01-cannon.zig"),
             .target = target,
             .optimize = optimize,
         });
@@ -33,7 +33,7 @@ pub fn build(b: *std.Build) void {
     {
         const exe = b.addExecutable(.{
             .name = "chapter-02-cannon",
-            .root_source_file = .{ .path = "src/chapter-02-cannon.zig" },
+            .root_source_file = b.path("src/chapter-02-cannon.zig"),
             .target = target,
             .optimize = optimize,
         });


### PR DESCRIPTION
- Switch to a public build API. (A private API accidentlly used, and that broke.)
- Rename of Zig cache directory by .zig-cache.